### PR TITLE
feat: rewrite bootstrap with cmake install and baked prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Build output
-build/
+build*/
+cmake-build-*/
+lib
 
 # IDE
 .idea/
@@ -11,7 +13,9 @@ build/
 .DS_Store
 .cache/
 
+# Coverage
 *.profraw
+*.profdata
 
 # ccbuild self dir
 **/.ccbuild/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,11 +101,9 @@ endif ()
 # ccbuild cli
 add_executable(ccbuild src/main.cc)
 target_link_libraries(ccbuild PRIVATE ccbuildlib)
-
 target_compile_definitions(ccbuild PRIVATE
-        CCBUILD_INCLUDE_DIR="${CMAKE_SOURCE_DIR}/include"
-        CCBUILD_LIB_DIR="${CMAKE_BINARY_DIR}"
-        CCBUILD_NINJA_INCLUDE_DIR="${CMAKE_SOURCE_DIR}/ninja/src"
+    CCBUILD_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}"
+    CCBUILD_BINARY_DIR="${CMAKE_BINARY_DIR}"
 )
 
 # When libraries are coverage-instrumented, the runner must also link with
@@ -120,7 +118,14 @@ if (CCBUILD_COVERAGE)
     endif ()
 endif ()
 
-# tests
+# -- install rules ------------------------------------------------------
+include(GNUInstallDirs)
+
+install(TARGETS ccbuild RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS ccbuildlib ninjacore ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(DIRECTORY include/ccbuild DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# -- tests -------------------------------------------------------------
 include(CTest)
 if (BUILD_TESTING)
     include(FetchContent)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `ccbuild` CLI compiles your build script, caches the result, and executes it
 
 ## Quick Start
 
-### 1. Installation
+### 1. Bootstrap via CMake
 
 Ensure you have a C++20 compiler, CMake 3.15+, and a POSIX system (macOS/Linux).
 
@@ -30,11 +30,19 @@ Ensure you have a C++20 compiler, CMake 3.15+, and a POSIX system (macOS/Linux).
 git clone --recursive https://github.com/aniket-ray/ccbuild.git
 cd ccbuild
 
+# Bootstrap: build with CMake, then install to /usr/local (or your prefix)
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
-
-sudo cp build/ccbuild /usr/local/bin/
+sudo cmake --install build
 ```
+
+The install step places the binary (`ccbuild`), libraries (`libccbuildlib.a`, `libninjacore.a`), and headers (`ccbuild/*.h`) under the install prefix. The install path is baked into the binary at compile time — no directory crawling needed at runtime.
+
+> **Self-hosting:** After the initial CMake bootstrap, ccbuild can rebuild itself:
+> ```bash
+> cd ccbuild
+> ccbuild            # uses build.cc to rebuild itself
+> ```
 
 ### 2. Write your `build.cc`
 

--- a/build.cc
+++ b/build.cc
@@ -1,0 +1,79 @@
+/// ccbuild's self-hosting build script.
+///
+/// This is the canonical build.cc that ccbuild uses to build itself.
+/// After the initial CMake bootstrap, running `ccbuild` in the repo root
+/// compiles and executes this script via the cached runner.
+///
+/// Targets:
+///   - ninjacore:  static library from the ninja submodule
+///   - ccbuildlib: static library from ccbuild's own source
+///   - ccbuild:    CLI executable linking both libraries
+
+#include <ccbuild/ccbuild.h>
+
+#include <thread>
+
+int main() {
+  ccbuild::Project p("ccbuild");
+  p.set_cxx_standard(20);
+
+  // -- ninjacore: Ninja build engine (static library) --------------------
+  auto& ninjacore =
+      p.add_library("ninjacore", {
+                                     "ninja/src/build_log.cc",
+                                     "ninja/src/build.cc",
+                                     "ninja/src/clean.cc",
+                                     "ninja/src/clparser.cc",
+                                     "ninja/src/debug_flags.cc",
+                                     "ninja/src/depfile_parser.cc",
+                                     "ninja/src/deps_log.cc",
+                                     "ninja/src/disk_interface.cc",
+                                     "ninja/src/dyndep.cc",
+                                     "ninja/src/dyndep_parser.cc",
+                                     "ninja/src/edit_distance.cc",
+                                     "ninja/src/elide_middle.cc",
+                                     "ninja/src/eval_env.cc",
+                                     "ninja/src/explanations.cc",
+                                     "ninja/src/graph.cc",
+                                     "ninja/src/graphviz.cc",
+                                     "ninja/src/jobserver.cc",
+                                     "ninja/src/jobserver-posix.cc",
+                                     "ninja/src/json.cc",
+                                     "ninja/src/lexer.cc",
+                                     "ninja/src/line_printer.cc",
+                                     "ninja/src/manifest_parser.cc",
+                                     "ninja/src/metrics.cc",
+                                     "ninja/src/missing_deps.cc",
+                                     "ninja/src/parser.cc",
+                                     "ninja/src/real_command_runner.cc",
+                                     "ninja/src/state.cc",
+                                     "ninja/src/status_printer.cc",
+                                     "ninja/src/string_piece_util.cc",
+                                     "ninja/src/subprocess-posix.cc",
+                                     "ninja/src/util.cc",
+                                     "ninja/src/version.cc",
+                                 });
+  ninjacore.add_include_dirs({ "ninja/src" }, ccbuild::Visibility::Private);
+  ninjacore.add_compile_options({ "-w" });
+
+  // -- ccbuildlib: ccbuild core (static library) -------------------------
+  auto& ccbuildlib =
+      p.add_library("ccbuildlib", {
+                                      "src/core/target.cc",
+                                      "src/targets/executable.cc",
+                                      "src/targets/static_library.cc",
+                                      "src/internal/ninja_bridge.cc",
+                                      "src/internal/compiler.cc",
+                                      "src/project/project.cc",
+                                  });
+  ccbuildlib.add_include_dirs({ "include", "ninja/src", "src" },
+                              ccbuild::Visibility::Private);
+  ccbuildlib.link(ninjacore);
+
+  // -- ccbuild: CLI executable -------------------------------------------
+  auto& cli = p.add_executable("ccbuild", { "src/main.cc" });
+  cli.link(ccbuildlib).link(ninjacore);
+  cli.add_link_options({ "-lpthread" });
+
+  return p.build();
+}

--- a/src/main.cc
+++ b/src/main.cc
@@ -2,77 +2,159 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <climits>
 #include <cstdio>
+#include <cstdlib>
 #include <filesystem>
 #include <string>
+#include <string_view>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif
 
 namespace fs = std::filesystem;
 
-// Paths embedded by CMake at compile time.
-#ifndef CCBUILD_INCLUDE_DIR
-#error "CCBUILD_INCLUDE_DIR must be defined by CMake"
-#endif
-#ifndef CCBUILD_LIB_DIR
-#error "CCBUILD_LIB_DIR must be defined by CMake"
-#endif
-#ifndef CCBUILD_NINJA_INCLUDE_DIR
-#error "CCBUILD_NINJA_INCLUDE_DIR must be defined by CMake"
+// -- Constants -----------------------------------------------------------
+
+static constexpr std::string_view kBuildFile = "build.cc";
+static constexpr std::string_view kRunnerDir = ".ccbuild";
+static constexpr std::string_view kRunnerBin = ".ccbuild/runner";
+static constexpr int64_t kNanosecondsPerSecond = 1'000'000'000;
+static constexpr int kSignalExitBase = 128;
+
+// -- Locate ccbuild's installed resources --------------------------------
+//
+// The install prefix is baked in at compile-time by CMake:
+//   -DCCBUILD_INSTALL_PREFIX="/usr/local"
+//
+// Headers live at ${prefix}/include, libraries at ${prefix}/lib.
+// If the binary is running from the build tree (pre-install), we fall
+// back to paths relative to the binary's own location.
+
+#ifndef CCBUILD_INSTALL_PREFIX
+#define CCBUILD_INSTALL_PREFIX "/usr/local"
 #endif
 
-static const std::string build_file = "build.cc";
-static const std::string runner_dir = ".ccbuild";
-static const std::string runner_bin = ".ccbuild/runner";
+/// Return the absolute path of the currently running executable.
+static fs::path self_exe_path() {
+#if defined(__APPLE__)
+  char buf[PATH_MAX];
+  uint32_t size = sizeof(buf);
+  if (_NSGetExecutablePath(buf, &size) == 0) {
+    std::error_code ec;
+    auto p = fs::canonical(buf, ec);
+    if (!ec)
+      return p;
+    return buf;
+  }
+#else  // Linux / POSIX
+  char buf[PATH_MAX];
+  ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+  if (len != -1) {
+    buf[len] = '\0';
+    std::error_code ec;
+    auto p = fs::canonical(buf, ec);
+    if (!ec)
+      return p;
+    return buf;
+  }
+#endif
+  return {};
+}
 
-static constexpr int64_t ns_per_sec = 1'000'000'000;
-static constexpr int signal_exit_base = 128;
+/// Determine ccbuild's resource root directory.
+///
+/// Strategy:
+///   1. Use the compile-time install prefix (CCBUILD_INSTALL_PREFIX) if its
+///      include/ccbuild/ccbuild.h exists -- this is the normal installed case.
+///   2. Otherwise, walk up from the executable's location looking for
+///      include/ccbuild/ccbuild.h -- this handles running from the build tree
+///      during development.
+///   3. Last resort: fall back to the current working directory.
+static std::string find_ccbuild_root() {
+  const fs::path prefix = CCBUILD_INSTALL_PREFIX;
+  std::error_code ec;
+  if (fs::exists(prefix / "include" / "ccbuild" / "ccbuild.h", ec)) {
+    return prefix.string();
+  }
 
-// Get the modification time of a file (nanosecond precision).
-// Returns 0 if the file doesn't exist.
+  // Walk up from the binary's directory looking for the include tree.
+  auto exe = self_exe_path();
+  if (!exe.empty()) {
+    for (auto dir = exe.parent_path();
+         !dir.empty() && dir != dir.root_directory(); dir = dir.parent_path()) {
+      if (fs::exists(dir / "include" / "ccbuild" / "ccbuild.h", ec)) {
+        return dir.string();
+      }
+    }
+  }
+
+  // Last resort: current working directory.
+  return fs::current_path(ec).string();
+}
+
+/// Get the modification time of a file in nanoseconds since epoch.
+/// @return The mtime, or 0 if the file cannot be stat'd.
 static int64_t file_mtime_ns(const std::string& path) {
   struct stat st;
-  if (stat(path.c_str(), &st) != 0)
+  if (stat(path.c_str(), &st) != 0) {
     return 0;
+  }
 #if defined(__APPLE__)
-  return static_cast<int64_t>(st.st_mtimespec.tv_sec) * ns_per_sec +
+  return static_cast<int64_t>(st.st_mtimespec.tv_sec) * kNanosecondsPerSecond +
          st.st_mtimespec.tv_nsec;
 #else
-  return static_cast<int64_t>(st.st_mtim.tv_sec) * ns_per_sec +
+  return static_cast<int64_t>(st.st_mtim.tv_sec) * kNanosecondsPerSecond +
          st.st_mtim.tv_nsec;
 #endif
 }
-// Check if the cached runner is still valid (build.cc hasn't changed).
+
+/// Check whether the cached runner binary is newer than build.cc.
+/// If so, we can skip recompilation.
 static bool runner_is_cached(const std::string& build_cc,
                              const std::string& runner) {
-  auto runner_mtime = file_mtime_ns(runner);
-  if (runner_mtime == 0)
-    return false;  // Runner doesn't exist.
-
-  auto build_mtime = file_mtime_ns(build_cc);
+  const auto runner_mtime = file_mtime_ns(runner);
+  if (runner_mtime == 0) {
+    return false;
+  }
+  const auto build_mtime = file_mtime_ns(build_cc);
   return runner_mtime > build_mtime;
 }
 
-// Compile build.cc into .ccbuild/runner.
+/// Compile the build.cc script into the runner binary.
+/// @return 0 on success, non-zero on compilation failure.
 static int compile_build_cc(const std::string& build_cc,
                             const std::string& runner) {
-  // Ensure output directory exists.
-  fs::create_directories(runner_dir);
+  fs::create_directories(kRunnerDir);
 
-  // Build the compile command.
-  // Link order matters: ccbuildlib first (depends on ninjacore), then
-  // ninjacore.
+  const auto root = find_ccbuild_root();
+
+  // Determine the library directory -- on some distros it's lib64.
+  std::string lib_dir = root + "/lib";
+  {
+    std::error_code ec;
+    if (!fs::exists(lib_dir + "/libccbuildlib.a", ec)) {
+      const std::string alt = root + "/lib64";
+      if (fs::exists(alt + "/libccbuildlib.a", ec)) {
+        lib_dir = alt;
+      }
+    }
+  }
+
+  // Build the compiler command.
   std::string cmd;
 #ifdef __APPLE__
   cmd += "c++ -std=c++20 -g";
 #else
   cmd += "g++ -std=c++20 -g";
 #endif
-  cmd += " -I" CCBUILD_INCLUDE_DIR;
-  cmd += " -I" CCBUILD_NINJA_INCLUDE_DIR;
+  cmd += " -I" + root + "/include";
   cmd += " " + build_cc;
-  cmd += " -L" CCBUILD_LIB_DIR;
+  cmd += " -L" + lib_dir;
   cmd += " -lccbuildlib -lninjacore";
 #ifndef __APPLE__
-  cmd += " -lstdc++fs";  // needed on older Linux GCC for std::filesystem
+  cmd += " -lstdc++fs";
 #endif
   cmd += " -lpthread";
 #ifdef CCBUILD_COVERAGE_LINK_FLAGS
@@ -84,8 +166,9 @@ static int compile_build_cc(const std::string& build_cc,
   fprintf(stderr, "ccbuild: compiling %s...\n", build_cc.c_str());
 
   int rc = system(cmd.c_str());
-  if (WIFEXITED(rc))
+  if (WIFEXITED(rc)) {
     rc = WEXITSTATUS(rc);
+  }
   if (rc != 0) {
     fprintf(stderr, "ccbuild: failed to compile %s\n", build_cc.c_str());
     fprintf(stderr, "  command: %s\n", cmd.c_str());
@@ -94,33 +177,40 @@ static int compile_build_cc(const std::string& build_cc,
   return 0;
 }
 
-// Run the compiled runner binary, forwarding the exit code.
+/// Execute the runner binary.
+/// @return The runner's exit code, or a signal-based code if killed.
 static int run_runner(const std::string& runner) {
-  int rc = system(runner.c_str());
-  if (WIFEXITED(rc))
+  const int rc = system(runner.c_str());
+  if (WIFEXITED(rc)) {
     return WEXITSTATUS(rc);
+  }
   if (WIFSIGNALED(rc)) {
     fprintf(stderr, "ccbuild: runner killed by signal %d\n", WTERMSIG(rc));
-    return signal_exit_base + WTERMSIG(rc);
+    return kSignalExitBase + WTERMSIG(rc);
   }
   return 1;
 }
 
+// -- Entry Point ---------------------------------------------------------
+
 int main(int argc, char* argv[]) {
-  // Check for build.cc in the current directory.
-  if (!fs::exists(build_file)) {
+  (void)argc;
+  (void)argv;
+
+  if (!fs::exists(kBuildFile)) {
     fprintf(stderr, "ccbuild: error: no %s found in current directory.\n",
-            build_file.c_str());
+            kBuildFile.data());
     return 1;
   }
 
-  // Compile build.cc if needed (cache check).
-  if (!runner_is_cached(build_file, runner_bin)) {
-    int rc = compile_build_cc(build_file, runner_bin);
-    if (rc != 0)
+  // Recompile the runner if build.cc is newer than the cached binary.
+  if (!runner_is_cached(std::string(kBuildFile), std::string(kRunnerBin))) {
+    const int rc =
+        compile_build_cc(std::string(kBuildFile), std::string(kRunnerBin));
+    if (rc != 0) {
       return rc;
+    }
   }
 
-  // Run the compiled build script.
-  return run_runner(runner_bin);
+  return run_runner(std::string(kRunnerBin));
 }


### PR DESCRIPTION
## Summary

Replace the manual shell bootstrap script with a CMake-based install system that bakes the installation prefix into the binary.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Testing

- [x] All tests pass locally
- [ ] New gtest tests added for new functionality
- [x] Clang-format compliance on changed files
- [x] My changes generate no new compiler warnings

## Checklist

- [x] I have written/updated gtest tests for my changes
- [x] All tests pass locally with ctest
- [x] Clang-format compliance on changed files
- [x] My changes generate no new compiler warnings
- [ ] I have updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CMake installation rules for ccbuild executable, static libraries, and public headers
  * Implemented self-hosting build configuration enabling ccbuild to build itself using its own build system

* **Chores**
  * Updated `.gitignore` to exclude additional build artifact patterns and coverage data files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->