### PR TITLE
fix(ninja): library archives, transitive deps, QA improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ if (BUILD_TESTING)
             tests/targets/static_library_test.cc
             tests/internal/validators_test.cc
             tests/internal/compiler_test.cc
+            tests/internal/ninja_bridge_test.cc
             tests/project/project_test.cc
     )
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,11 @@ coverage:
   status:
     project:
       default:
-        target: 50%
+        target: 85%
         threshold: 2%
     patch:
       default:
-        target: 50%
+        target: 85%
         threshold: 5%
 
 comment:

--- a/examples/loganalyzer/build.cc
+++ b/examples/loganalyzer/build.cc
@@ -1,4 +1,4 @@
-/// loganalyzer — build.cc
+/// loganalyzer -- build.cc
 ///
 /// This project exercises ccbuild with:
 ///   - 3 static libraries (csv, stats, analyzer)
@@ -26,7 +26,7 @@ int main() {
       "stats", { "src/stats/summary.cc", "src/stats/counter.cc" });
   stats.add_compile_options({ "-Isrc" });
 
-  // Log analyzer library — depends on csv for parsing log files.
+  // Log analyzer library -- depends on csv for parsing log files.
   auto& analyzer = p.add_library(
       "analyzer", { "src/analyzer/log_entry.cc", "src/analyzer/filter.cc" });
   analyzer.add_compile_options({ "-Isrc" });

--- a/examples/loganalyzer/src/stats/counter.h
+++ b/examples/loganalyzer/src/stats/counter.h
@@ -8,7 +8,7 @@
 
 namespace stats {
 
-/// Frequency counter — counts occurrences of string keys.
+/// Frequency counter -- counts occurrences of string keys.
 class Counter {
  public:
   void add(const std::string& key);

--- a/examples/loganalyzer/src/summarizer/main.cc
+++ b/examples/loganalyzer/src/summarizer/main.cc
@@ -1,4 +1,4 @@
-/// logsummary — Compute statistics over a CSV log file.
+/// logsummary -- Compute statistics over a CSV log file.
 ///
 /// Usage: logsummary <file.csv>
 

--- a/examples/loganalyzer/src/viewer/main.cc
+++ b/examples/loganalyzer/src/viewer/main.cc
@@ -1,4 +1,4 @@
-/// logview — View and filter log entries from a CSV log file.
+/// logview -- View and filter log entries from a CSV log file.
 ///
 /// Usage: logview <file.csv> [--level WARN] [--source auth] [--grep timeout]
 

--- a/include/ccbuild/ccbuild.h
+++ b/include/ccbuild/ccbuild.h
@@ -1,5 +1,8 @@
 #pragma once
 
+/// Umbrella header for the ccbuild library.
+/// Include this single header to use the entire public API.
+
 #include "ccbuild/executable.h"
 #include "ccbuild/project.h"
 #include "ccbuild/static_library.h"

--- a/include/ccbuild/executable.h
+++ b/include/ccbuild/executable.h
@@ -1,19 +1,32 @@
 #ifndef CCBUILD_EXECUTABLE_H
 #define CCBUILD_EXECUTABLE_H
 
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include "ccbuild/target.h"
 
 namespace ccbuild {
+
+/// An executable build target.
+///
+/// Produces a binary at .ccbuild/bin/<name>.  Executables may link
+/// against static libraries but not against other executables.
 class Executable final : public Target {
  public:
+  /// @param name    Unique name (also the binary name).
+  /// @param sources Source files to compile.
   Executable(std::string_view name, std::vector<std::string> sources);
 
   [[nodiscard]] TargetKind kind() const override {
     return TargetKind::Executable;
   }
 
+  /// @return ".ccbuild/bin/<name>"
   [[nodiscard]] std::string output_filename() const override;
 };
+
 }  // namespace ccbuild
 
 #endif  // CCBUILD_EXECUTABLE_H

--- a/include/ccbuild/project.h
+++ b/include/ccbuild/project.h
@@ -3,26 +3,63 @@
 
 #include <memory>
 #include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
 
 #include "ccbuild/executable.h"
 #include "ccbuild/static_library.h"
 
 namespace ccbuild {
+
+/// Top-level container for a ccbuild project.
+///
+/// Owns all build targets (Executable, StaticLibrary) and orchestrates
+/// validation and the build process.  This is the primary entry point
+/// for ccbuild build scripts (build.cc).
+///
+/// Usage:
+/// @code
+///   Project p("myproject");
+///   p.set_cxx_standard(20);
+///   auto& lib = p.add_library("mylib", {"lib.cc"});
+///   auto& exe = p.add_executable("myapp", {"main.cc"});
+///   exe.link(lib);
+///   return p.build();
+/// @endcode
 class Project {
  public:
+  /// Create a new project with the given name.
   explicit Project(std::string_view name);
-  void set_cxx_standard(int std);
 
+  /// Set the C++ standard version to compile with (e.g. 17, 20, 23).
+  /// Defaults to C++17.
+  void set_cxx_standard(int cxx_standard);
+
+  /// Register a new executable target.
+  ///
+  /// Ownership remains with the Project; the returned reference is valid
+  /// for the lifetime of the Project.
   Executable& add_executable(std::string_view name,
                              std::initializer_list<std::string> sources);
 
+  /// Register a new static library target.
+  ///
+  /// Ownership remains with the Project; the returned reference is valid
+  /// for the lifetime of the Project.
   StaticLibrary& add_library(std::string_view name,
                              std::initializer_list<std::string> sources);
 
-  // validate the model and execute the build
-  // if dry_run is true, only validates and print the plan without compiling
-  // return 0 on success, non-zero on error
+  /// Validate the project model and execute the build.
+  ///
+  /// @param dry_run  If true, validates and prints the build plan without
+  ///                 actually compiling or linking.
+  /// @return 0 on success, non-zero on validation or build failure.
   [[nodiscard]] int build(bool dry_run = false);
+
+  /// @name Accessors
+  /// @{
 
   [[nodiscard]] std::string_view name() const { return name_; }
   [[nodiscard]] int standard() const { return standard_; }
@@ -30,15 +67,21 @@ class Project {
     return targets_;
   }
 
+  /// @}
+
  private:
   friend class NinjaBridge;
 
+  /// Validate the project model, returning an error message on failure.
+  /// Checks: unique target names, non-empty sources, valid extensions,
+  /// no executable-to-executable links, no link cycles.
   [[nodiscard]] std::optional<std::string> validate() const;
 
   std::string name_;
   int standard_ = 17;
   std::vector<std::unique_ptr<Target>> targets_;
 };
+
 }  // namespace ccbuild
 
 #endif  // CCBUILD_PROJECT_H

--- a/include/ccbuild/static_library.h
+++ b/include/ccbuild/static_library.h
@@ -1,19 +1,33 @@
 #ifndef CCBUILD_STATIC_LIBRARY_H
 #define CCBUILD_STATIC_LIBRARY_H
 
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include "ccbuild/target.h"
 
 namespace ccbuild {
+
+/// A static library build target.
+///
+/// Produces an archive at .ccbuild/lib/lib<name>.a.  Static libraries
+/// may link against other static libraries, transitively propagating
+/// their public and interface include directories.
 class StaticLibrary final : public Target {
  public:
+  /// @param name    Unique name (also the library base name).
+  /// @param sources Source files to compile.
   StaticLibrary(std::string_view name, std::vector<std::string> sources);
 
   [[nodiscard]] TargetKind kind() const override {
     return TargetKind::StaticLibrary;
   }
 
+  /// @return ".ccbuild/lib/lib<name>.a"
   [[nodiscard]] std::string output_filename() const override;
 };
+
 }  // namespace ccbuild
 
 #endif  // CCBUILD_STATIC_LIBRARY_H

--- a/include/ccbuild/target.h
+++ b/include/ccbuild/target.h
@@ -11,20 +11,48 @@
 #include "ccbuild/types.h"
 
 namespace ccbuild {
+
 class NinjaBridge;
 
+/// Abstract base for all build targets (executables, static libraries, etc.).
+///
+/// Targets own their sources, compile options, link dependencies,
+/// and include directories.  The fluent API returns Target& from every
+/// mutator so that callers can chain configuration calls.
+///
+/// Targets are non-copyable and non-movable -- the Project owns them
+/// via std::unique_ptr<Target> and exposes them by reference.
 class Target {
  public:
   virtual ~Target() = default;
 
+  /// @name Identity
+  /// @{
+
+  /// The unique name of this target within the project.
   [[nodiscard]] std::string_view name() const { return name_; }
+
+  /// Which kind of target this is (Executable or StaticLibrary).
   [[nodiscard]] virtual TargetKind kind() const = 0;
+
+  /// The path to the final build artifact (.ccbuild/bin/<name>
+  /// or .ccbuild/lib/lib<name>.a).
   [[nodiscard]] virtual std::string output_filename() const = 0;
+
+  /// @}
+
+  /// @name Sources
+  /// @{
+
+  /// The source files that make up this target.
   [[nodiscard]] std::span<const std::string> sources() const {
     return sources_;
   }
 
-  /// append sources from any range of string-convertible elements
+  /// Append sources from any range of string-convertible elements
+  /// (std::vector<std::string>, std::vector<std::string_view>, etc.).
+  ///
+  /// Constrained by the SourceRange concept (types.h).
   template <SourceRange R>
   Target& add_sources(R&& range) {
     for (auto&& source : range) {
@@ -33,37 +61,97 @@ class Target {
     return *this;
   }
 
-  /// overload for brace-enclosed initializer lists
+  /// Overload for brace-enclosed initializer lists.
   Target& add_sources(std::initializer_list<std::string> sources) {
     sources_.insert(sources_.end(), sources.begin(), sources.end());
     return *this;
   }
 
-  /// link dependencies
+  /// @}
+
+  /// @name Link Dependencies
+  /// @{
+
+  /// Add a link dependency on another target.
+  ///
+  /// Only library targets may be linked against; linking an executable
+  /// throws std::invalid_argument.  The dependency is stored by reference --
+  /// the caller must ensure the referred target outlives this one.
   Target& link(Target& dep);
+
+  /// All direct link dependencies, in the order they were added.
   [[nodiscard]] std::span<const std::reference_wrapper<Target>> link_deps()
       const {
     return link_deps_;
   }
 
-  /// compile options
+  /// @}
+
+  /// @name Compile Options
+  /// @{
+
+  /// Add compiler flags (e.g. "-Wall", "-O2") that apply to every
+  /// source file in this target.
   Target& add_compile_options(std::initializer_list<std::string> opts);
+
+  /// All compile options in the order they were added.
   [[nodiscard]] std::span<const std::string> compile_options() const {
     return compile_options_;
   }
 
-  /// include directories with visibility
+  /// @}
+
+  /// @name Include Directories
+  /// @{
+
+  /// Add include directories at the given Visibility level.
+  ///
+  /// Visibility semantics:
+  ///   - Private:   used when compiling this target only.
+  ///   - Public:    used when compiling this target and anything that links it.
+  ///   - Interface: used only by targets that link this one (not by this target
+  ///     itself).  Useful for header-only libraries.
   Target& add_include_dirs(std::initializer_list<std::string> dirs,
                            Visibility vis);
+
+  /// Retrieve include directories for a given visibility level.
   [[nodiscard]] std::span<const std::string> include_dirs(Visibility vis) const;
 
+  /// @}
+
+  /// @name Link Options
+  /// @{
+
+  /// Add flags passed to the linker (e.g. "-lpthread", "-ldl").
+  Target& add_link_options(std::initializer_list<std::string> opts);
+
+  /// All link options in the order they were added.
+  [[nodiscard]] std::span<const std::string> link_options() const {
+    return link_options_;
+  }
+
+  /// @}
+
+  /// @name Build Artifact Paths
+  /// @{
+
+  /// Compute the object file path for a given source file.
+  ///
+  /// Output: .ccbuild/obj/<target_name>/<stem>.o
+  /// (the stem is the source path with its extension stripped).
   [[nodiscard]] std::string object_path(std::string_view source) const;
 
-  /// Non-copyable, non-movable
+  /// @}
+
+  /// Targets are non-copyable and non-movable.
+  /// The Project owns them via unique_ptr; external code works through
+  /// references.
   Target(const Target&) = delete;
   Target& operator=(const Target&) = delete;
 
  protected:
+  /// Construct a target with a name and initial source list.
+  /// Called only by derived classes (Executable, StaticLibrary).
   Target(std::string_view name, std::vector<std::string> sources);
 
  private:
@@ -73,6 +161,7 @@ class Target {
   std::vector<std::string> sources_;
   std::vector<std::reference_wrapper<Target>> link_deps_;
   std::vector<std::string> compile_options_;
+  std::vector<std::string> link_options_;
   std::vector<std::string> private_include_dirs_;
   std::vector<std::string> public_include_dirs_;
   std::vector<std::string> interface_include_dirs_;

--- a/include/ccbuild/types.h
+++ b/include/ccbuild/types.h
@@ -6,13 +6,27 @@
 #include <string>
 
 namespace ccbuild {
+
+/// Visibility level for include directories.
+/// Determines how include paths propagate to dependent targets.
+///
+///   - Private:  used by this target only, not inherited by dependents.
+///   - Public:   used by this target and inherited by direct dependents.
+///   - Interface: not used by this target, but inherited by dependents
+///     (useful for header-only dependencies).
 enum class Visibility { Public, Private, Interface };
+
+/// The kind of build target.
 enum class TargetKind { Executable, StaticLibrary };
 
+/// Concept: a range whose elements are convertible to std::string.
+/// Used to constrain add_sources() so that any string-like range
+/// (vector<string>, list<string>, vector<string_view>, etc.) works.
 template <typename R>
 concept SourceRange =
     std::ranges::input_range<R> &&
     std::convertible_to<std::ranges::range_value_t<R>, std::string>;
+
 }  // namespace ccbuild
 
 #endif  // CCBUILD_TYPES_H

--- a/src/core/target.cc
+++ b/src/core/target.cc
@@ -1,15 +1,21 @@
 #include "ccbuild/target.h"
 
-#include <cstdio>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
 
 namespace ccbuild {
+
+// -- Construction --------------------------------------------------------
+
 Target::Target(std::string_view name, std::vector<std::string> sources)
     : name_(name), sources_(std::move(sources)) {}
 
+// -- Link Dependencies ---------------------------------------------------
+
 Target& Target::link(Target& dep) {
+  // Only libraries can be linked against -- executables are leaf nodes.
   if (dep.kind() == TargetKind::Executable) {
     throw std::invalid_argument("cannot link against executable '" +
                                 std::string(dep.name()) + "'");
@@ -18,18 +24,32 @@ Target& Target::link(Target& dep) {
   return *this;
 }
 
+// -- Compile Options -----------------------------------------------------
+
 Target& Target::add_compile_options(std::initializer_list<std::string> opts) {
   compile_options_.insert(compile_options_.end(), opts.begin(), opts.end());
   return *this;
 }
 
+// -- Link Options --------------------------------------------------------
+
+Target& Target::add_link_options(std::initializer_list<std::string> opts) {
+  link_options_.insert(link_options_.end(), opts.begin(), opts.end());
+  return *this;
+}
+
+// -- Object Path ---------------------------------------------------------
+
 std::string Target::object_path(std::string_view source) const {
-  auto dot = source.rfind('.');
-  auto stem = (dot != std::string_view::npos) ? source.substr(0, dot) : source;
+  // Strip the file extension to get the stem.
+  const auto dot = source.rfind('.');
+  const auto stem =
+      (dot != std::string_view::npos) ? source.substr(0, dot) : source;
 
   static constexpr std::string_view kObjPrefix = ".ccbuild/obj/";
   static constexpr std::string_view kObjSuffix = ".o";
 
+  // Build path: .ccbuild/obj/<target_name>/<stem>.o
   std::string result;
   result.reserve(kObjPrefix.size() + name_.size() + 1 + stem.size() +
                  kObjSuffix.size());
@@ -41,9 +61,12 @@ std::string Target::object_path(std::string_view source) const {
   return result;
 }
 
+// -- Include Directories -------------------------------------------------
+
 Target& Target::add_include_dirs(std::initializer_list<std::string> dirs,
                                  Visibility vis) {
-  auto& target = [&]() -> std::vector<std::string>& {
+  // Select the appropriate include directory vector for the given visibility.
+  auto& target = [this, vis]() -> std::vector<std::string>& {
     switch (vis) {
     case Visibility::Private:
       return private_include_dirs_;
@@ -54,6 +77,7 @@ Target& Target::add_include_dirs(std::initializer_list<std::string> dirs,
     }
     return public_include_dirs_;
   }();
+
   target.insert(target.end(), dirs.begin(), dirs.end());
   return *this;
 }

--- a/src/internal/compiler.cc
+++ b/src/internal/compiler.cc
@@ -2,98 +2,14 @@
 
 #include <array>
 #include <cstdio>
+#include <cstdlib>
 #include <filesystem>
 #include <regex>
+#include <string>
 
 namespace ccbuild {
-namespace internal {
 
-CompilerKind identify_kind(std::string_view version_output) {
-  if (version_output.find("clang") != std::string::npos)
-    return CompilerKind::Clang;
-  if (version_output.find("g++") != std::string::npos ||
-      version_output.find("GCC") != std::string::npos ||
-      version_output.find("gcc") != std::string::npos)
-    return CompilerKind::Gcc;
-  return CompilerKind::Unknown;
-}
-
-std::string extract_version(const std::string& version_output) {
-  std::regex re(R"((\d+\.\d+\.\d+))");
-  std::smatch match;
-  if (std::regex_search(version_output, match, re))
-    return match[1].str();
-  return {};
-}
-
-int extract_major(const std::string& version) {
-  if (version.empty())
-    return 0;
-  try {
-    return std::stoi(version);
-  } catch (...) {
-    return 0;
-  }
-}
-
-}  // namespace internal
-
-namespace {
-
-namespace fs = std::filesystem;
-
-/// Run a command and capture its first line of stdout.
-std::string capture_stdout(const std::string& cmd) {
-  static constexpr std::size_t kBufferSize = 256;
-  std::array<char, kBufferSize> buf;
-  std::string result;
-  FILE* pipe = popen(cmd.c_str(), "r");
-  if (!pipe)
-    return {};
-  while (fgets(buf.data(), buf.size(), pipe))
-    result += buf.data();
-  pclose(pipe);
-  // Trim trailing newline.
-  while (!result.empty() && (result.back() == '\n' || result.back() == '\r'))
-    result.pop_back();
-  return result;
-}
-
-/// Resolve a compiler name to a full path using `which`.
-/// Returns empty string if not found.
-std::string resolve_path(const std::string& name) {
-  auto output = capture_stdout("which " + name + " 2>/dev/null");
-  if (output.empty())
-    return {};
-  // Verify it's executable.
-  if (!fs::exists(output))
-    return {};
-  return output;
-}
-
-/// Try a single compiler candidate. Returns nullopt if not usable.
-std::optional<CompilerInfo> try_compiler(const std::string& name_or_path) {
-  // Resolve to full path.
-  std::string path = name_or_path;
-  if (!fs::exists(path))
-    path = resolve_path(name_or_path);
-  if (path.empty())
-    return std::nullopt;
-
-  // Get version output.
-  auto version_output = capture_stdout(path + " --version 2>&1");
-  if (version_output.empty())
-    return std::nullopt;
-
-  CompilerInfo info;
-  info.path = path;
-  info.kind = internal::identify_kind(version_output);
-  info.version = internal::extract_version(version_output);
-  info.major_version = internal::extract_major(info.version);
-  return info;
-}
-
-}  // namespace
+// -- CompilerKind Output -------------------------------------------------
 
 std::string_view CompilerInfo::kind_str() const {
   switch (kind) {
@@ -107,17 +23,136 @@ std::string_view CompilerInfo::kind_str() const {
   return "Unknown";
 }
 
-std::optional<CompilerInfo> detect_compiler() {
-  if (const char* cxx = std::getenv("CXX")) {
-    if (auto info = try_compiler(cxx))
-      return info;
+// -- Compiler Identification ---------------------------------------------
+
+namespace internal {
+
+CompilerKind identify_kind(std::string_view version_output) {
+  if (version_output.find("clang") != std::string_view::npos) {
+    return CompilerKind::Clang;
+  }
+  if (version_output.find("g++") != std::string_view::npos ||
+      version_output.find("GCC") != std::string_view::npos ||
+      version_output.find("gcc") != std::string_view::npos) {
+    return CompilerKind::Gcc;
+  }
+  return CompilerKind::Unknown;
+}
+
+std::string extract_version(const std::string& version_output) {
+  static const std::regex kVersionRe(R"((\d+\.\d+\.\d+))");
+  std::smatch match;
+  if (std::regex_search(version_output, match, kVersionRe)) {
+    return match[1].str();
+  }
+  return {};
+}
+
+int extract_major(const std::string& version) {
+  if (version.empty()) {
+    return 0;
+  }
+  try {
+    return std::stoi(version);
+  } catch (...) {
+    return 0;
+  }
+}
+
+}  // namespace internal
+
+// -- Compiler Detection Helpers (file-local) -----------------------------
+
+namespace {
+
+namespace fs = std::filesystem;
+
+/// Run a shell command and capture its stdout (first line, trimmed).
+/// Returns an empty string if the command fails or produces no output.
+std::string capture_stdout(const std::string& cmd) {
+  static constexpr std::size_t kBufferSize = 256;
+  std::array<char, kBufferSize> buf{};
+
+  FILE* pipe = popen(cmd.c_str(), "r");
+  if (pipe == nullptr) {
+    return {};
   }
 
-  if (auto info = try_compiler("g++"))
-    return info;
+  std::string result;
+  while (std::fgets(buf.data(), static_cast<int>(buf.size()), pipe) !=
+         nullptr) {
+    result += buf.data();
+  }
+  pclose(pipe);
 
-  if (auto info = try_compiler("clang++"))
+  // Trim trailing newline / carriage return.
+  while (!result.empty() && (result.back() == '\n' || result.back() == '\r')) {
+    result.pop_back();
+  }
+  return result;
+}
+
+/// Resolve a compiler name to a full path using `which`.
+/// Returns an empty string if the command is not found or not executable.
+std::string resolve_path(const std::string& name) {
+  const auto output = capture_stdout("which " + name + " 2>/dev/null");
+  if (output.empty()) {
+    return {};
+  }
+  if (!fs::exists(output)) {
+    return {};
+  }
+  return output;
+}
+
+/// Try to detect compiler info from a name or path candidate.
+/// Returns std::nullopt if the candidate cannot be found or produces
+/// no version output.
+std::optional<CompilerInfo> try_compiler(const std::string& name_or_path) {
+  // Resolve to full path if the candidate is not an absolute/existing path.
+  std::string path = name_or_path;
+  if (!fs::exists(path)) {
+    path = resolve_path(name_or_path);
+  }
+  if (path.empty()) {
+    return std::nullopt;
+  }
+
+  // Run --version and parse the output.
+  const auto version_output = capture_stdout(path + " --version 2>&1");
+  if (version_output.empty()) {
+    return std::nullopt;
+  }
+
+  CompilerInfo info;
+  info.path = path;
+  info.kind = internal::identify_kind(version_output);
+  info.version = internal::extract_version(version_output);
+  info.major_version = internal::extract_major(info.version);
+  return info;
+}
+
+}  // namespace
+
+// -- Public API ----------------------------------------------------------
+
+std::optional<CompilerInfo> detect_compiler() {
+  // Honour the $CXX environment variable if set and usable.
+  if (const char* cxx = std::getenv("CXX")) {
+    if (auto info = try_compiler(cxx)) {
+      return info;
+    }
+  }
+
+  // Try g++ as the most common default.
+  if (auto info = try_compiler("g++")) {
     return info;
+  }
+
+  // Fall back to clang++.
+  if (auto info = try_compiler("clang++")) {
+    return info;
+  }
 
   return std::nullopt;
 }

--- a/src/internal/compiler.h
+++ b/src/internal/compiler.h
@@ -1,30 +1,59 @@
 #ifndef CCBUILD_COMPILER_H
 #define CCBUILD_COMPILER_H
+
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace ccbuild {
 
+/// Identifies the compiler toolchain.
 enum class CompilerKind { Gcc, Clang, Unknown };
 
+/// Information about a detected C++ compiler.
 struct CompilerInfo {
+  /// Full path to the compiler binary (e.g. "/usr/bin/g++").
   std::string path;
+
+  /// Which compiler family was detected.
   CompilerKind kind = CompilerKind::Unknown;
+
+  /// Human-readable version string (e.g. "13.2.0").
   std::string version;
+
+  /// Major version number extracted from the version string,
+  /// or 0 if it could not be parsed.
   int major_version = 0;
 
+  /// @return "GCC", "Clang", or "Unknown" based on #kind.
   [[nodiscard]] std::string_view kind_str() const;
 };
 
+/// Detect the system C++ compiler.
+///
+/// Priority:
+///   1. The compiler named by the $CXX environment variable.
+///   2. g++ (found via PATH).
+///   3. clang++ (found via PATH).
+///
+/// @return CompilerInfo if a usable compiler was found, std::nullopt otherwise.
 [[nodiscard]] std::optional<CompilerInfo> detect_compiler();
 
+/// Implementation helpers used internally and in tests.
 namespace internal {
 
-CompilerKind identify_kind(std::string_view version_output);
-std::string extract_version(const std::string& version_output);
-int extract_major(const std::string& version);
+/// Identify the compiler family from its --version output.
+[[nodiscard]] CompilerKind identify_kind(std::string_view version_output);
+
+/// Extract a "X.Y.Z" version from compiler output using a regex.
+[[nodiscard]] std::string extract_version(const std::string& version_output);
+
+/// Parse the leading integer from a version string.
+/// @return The major version, or 0 on parse failure.
+[[nodiscard]] int extract_major(const std::string& version);
 
 }  // namespace internal
+
 }  // namespace ccbuild
 
 #endif  // CCBUILD_COMPILER_H

--- a/src/internal/ninja_bridge.cc
+++ b/src/internal/ninja_bridge.cc
@@ -1,22 +1,22 @@
 #include "internal/ninja_bridge.h"
 
-#include "ccbuild/project.h"
-#include "internal/compiler.h"
-
-// Ninja headers.
 #include <cstdio>
 #include <filesystem>
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_set>
+#include <vector>
 
 #include "build.h"
 #include "build_log.h"
+#include "ccbuild/project.h"
 #include "deps_log.h"
 #include "disk_interface.h"
 #include "eval_env.h"
+#include "internal/compiler.h"
 #include "metrics.h"
 #include "state.h"
 #include "status_printer.h"
@@ -24,12 +24,16 @@
 namespace ccbuild {
 namespace {
 
-/// Minimal BuildLogUser — no paths are dead since we build the full graph.
+// -- BuildLogUser for fresh builds ---------------------------------------
+
+/// Minimal BuildLogUser: no paths are dead since we always build the
+/// full dependency graph from scratch.
 struct NullBuildLogUser : public BuildLogUser {
   bool IsPathDead(StringPiece) const override { return false; }
 };
 
-/// Helper: build an EvalString from text and $variable references.
+// -- EvalString helpers --------------------------------------------------
+
 /// Append literal text to an EvalString.
 void text(EvalString& es, const char* s) {
   es.AddText(s);
@@ -40,17 +44,24 @@ void var(EvalString& es, const char* v) {
   es.AddSpecial(v);
 }
 
-/// Create the three build rules: cc, link, ar.
-void create_rules(State& state, const std::string& compiler, int standard) {
-  std::string std_flag = "-std=c++" + std::to_string(standard);
+// -- Rule Creation -------------------------------------------------------
 
+/// Create the three Ninja build rules (cc, link, ar) and register them
+/// with the Ninja State object.
+///
+/// @param state    The Ninja State into which rules are added.
+/// @param compiler Full path to the C++ compiler binary.
+/// @param standard The C++ standard version (e.g. 17, 20).
+void create_rules(State& state, const std::string& compiler, int standard) {
+  const std::string std_flag = "-std=c++" + std::to_string(standard);
+
+  // -- cc: compile a single source file → object file --------------------
   {
     auto rule = std::make_unique<Rule>("cc");
 
     EvalString cmd;
     text(cmd, (compiler + " " + std_flag + " ").c_str());
-    // Per-target compile options injected via $cflags.
-    var(cmd, "cflags");
+    var(cmd, "cflags");  // per-target compile options
     text(cmd, " -MD -MF ");
     var(cmd, "out");
     text(cmd, ".d -c ");
@@ -76,12 +87,14 @@ void create_rules(State& state, const std::string& compiler, int standard) {
     state.bindings_.AddRule(std::move(rule));
   }
 
-  // -- link: link object files -> executable ----------------------------
+  // -- link: combine object files → executable ---------------------------
   {
     auto rule = std::make_unique<Rule>("link");
 
     EvalString cmd;
     text(cmd, (compiler + " ").c_str());
+    var(cmd, "ldflags");  // per-target link flags
+    text(cmd, " ");
     var(cmd, "in");
     text(cmd, " -o ");
     var(cmd, "out");
@@ -95,12 +108,13 @@ void create_rules(State& state, const std::string& compiler, int standard) {
     state.bindings_.AddRule(std::move(rule));
   }
 
-  // -- ar: archive object files -> static library -----------------------
+  // -- ar: archive object files → static library -------------------------
   {
     auto rule = std::make_unique<Rule>("ar");
 
     EvalString cmd;
     text(cmd, "ar rcs ");
+    var(cmd, "ldflags");  // per-target linker flags
     var(cmd, "out");
     text(cmd, " ");
     var(cmd, "in");
@@ -115,70 +129,93 @@ void create_rules(State& state, const std::string& compiler, int standard) {
   }
 }
 
-// Add edges for a single target to the State.
-// Returns the output Node* for the final artifact (executable or .a).
+// -- Target Graph → Ninja Edges ------------------------------------------
+
+/// Translate a single Target into Ninja Edges and Nodes.
+///
+/// Steps:
+///   1. Build the cflags string from include dirs (with visibility
+///      propagation) and compile options.
+///   2. Create a compile Edge for each source → object file.
+///   3. Create a link or archive Edge to produce the final artifact.
+///
+/// @return The output Node representing the final build artifact.
 Node* add_target_edges(State& state, const Target& target) {
   const Rule* cc_rule = state.bindings_.LookupRule("cc");
   const Rule* link_rule = state.bindings_.LookupRule("link");
   const Rule* ar_rule = state.bindings_.LookupRule("ar");
 
-  // Build per-target cflags string.
+  // -- Build the per-target cflags string --------------------------------
   std::string cflags;
 
-  // Include directories with visibility propagation.
   {
     std::unordered_set<std::string_view> seen;
+
+    // Append "-I <dir>" for each directory, deduplicated.
     auto add_dir = [&](std::string_view dir) {
       if (seen.insert(dir).second) {
-        if (!cflags.empty())
+        if (!cflags.empty()) {
           cflags += ' ';
+        }
         cflags += "-I";
         cflags += dir;
       }
     };
+
     auto add_dirs = [&](std::span<const std::string> dirs) {
-      for (const auto& d : dirs)
+      for (const auto& d : dirs) {
         add_dir(d);
+      }
     };
 
-    // Own: PRIVATE + PUBLIC
+    // Own directories: PRIVATE + PUBLIC.
     add_dirs(target.include_dirs(Visibility::Private));
     add_dirs(target.include_dirs(Visibility::Public));
 
-    // Transitive from link deps: PUBLIC + INTERFACE
+    // Transitive directories from link dependencies: PUBLIC + INTERFACE.
+    // Uses a depth-first traversal with a visited set to avoid cycles
+    // (the project validation already guarantees DAG, but this is defensive).
     std::unordered_set<std::string_view> visited;
     std::function<void(const Target&)> collect = [&](const Target& t) {
-      if (!visited.insert(t.name()).second)
+      if (!visited.insert(t.name()).second) {
         return;
+      }
       add_dirs(t.include_dirs(Visibility::Public));
       add_dirs(t.include_dirs(Visibility::Interface));
-      for (const Target& dep : t.link_deps())
+      for (const Target& dep : t.link_deps()) {
         collect(dep);
+      }
     };
-    for (const Target& dep : target.link_deps())
+
+    for (const Target& dep : target.link_deps()) {
       collect(dep);
+    }
   }
 
-  // Compile options.
+  // Append per-target compile options to cflags.
   for (const auto& opt : target.compile_options()) {
-    if (!cflags.empty())
+    if (!cflags.empty()) {
       cflags += ' ';
+    }
     cflags += opt;
   }
 
-  // Compile each source -> object file.
+  // -- Compile each source → object file ---------------------------------
   std::vector<Node*> obj_nodes;
   for (const auto& src : target.sources()) {
-    std::string obj = target.object_path(src);
+    const std::string obj = target.object_path(src);
 
     // Ensure the output directory exists.
     auto obj_dir = std::filesystem::path(obj).parent_path();
-    if (!obj_dir.empty())
+    if (!obj_dir.empty()) {
       std::filesystem::create_directories(obj_dir);
+    }
 
     Edge* edge = state.AddEdge(cc_rule);
 
     // Set per-edge cflags binding.
+    // Note: env_ takes raw ownership via BindingEnv::release().
+    // This matches Ninja's internal ownership model.
     auto env = std::make_unique<BindingEnv>(&state.bindings_);
     env->AddBinding("cflags", cflags);
     edge->env_ = env.release();
@@ -190,29 +227,40 @@ Node* add_target_edges(State& state, const Target& target) {
     obj_nodes.push_back(state.GetNode(obj, 0));
   }
 
-  // link (executable) or archive (static library).
-  std::string output = target.output_filename();
+  // -- Final artifact: link or archive -----------------------------------
+  const std::string output = target.output_filename();
 
   // Ensure the output directory exists (e.g. .ccbuild/bin/, .ccbuild/lib/).
   auto out_dir = std::filesystem::path(output).parent_path();
-  if (!out_dir.empty())
+  if (!out_dir.empty()) {
     std::filesystem::create_directories(out_dir);
+  }
 
   const Rule* final_rule =
       (target.kind() == TargetKind::Executable) ? link_rule : ar_rule;
 
   Edge* final_edge = state.AddEdge(final_rule);
   auto final_env = std::make_unique<BindingEnv>(&state.bindings_);
+
+  // Build ldflags from per-target link options.
+  std::string ldflags;
+  for (const auto& opt : target.link_options()) {
+    if (!ldflags.empty()) {
+      ldflags += ' ';
+    }
+    ldflags += opt;
+  }
+  final_env->AddBinding("ldflags", ldflags);
   final_edge->env_ = final_env.release();
 
-  // Add all object files as inputs.
+  // Inputs: all compiled object files.
   for (auto* obj_node : obj_nodes) {
     state.AddIn(final_edge, obj_node->path(), 0);
   }
 
-  // Add link dependency outputs as inputs (for executables linking libraries).
+  // Inputs: outputs of link dependencies (for linking libraries together).
   for (const Target& dep : target.link_deps()) {
-    std::string dep_output = dep.output_filename();
+    const std::string dep_output = dep.output_filename();
     state.AddIn(final_edge, dep_output, 0);
   }
 
@@ -224,7 +272,10 @@ Node* add_target_edges(State& state, const Target& target) {
 
 }  // namespace
 
+// -- Public Interface ----------------------------------------------------
+
 int NinjaBridge::build(const Project& project) {
+  // 1. Detect the C++ compiler.
   auto compiler = detect_compiler();
   if (!compiler) {
     fprintf(stderr,
@@ -237,12 +288,13 @@ int NinjaBridge::build(const Project& project) {
           compiler->kind_str().data(), compiler->version.c_str(),
           compiler->path.c_str());
 
+  // 2. Create the Ninja build state and rules.
   State state;
   create_rules(state, compiler->path, project.standard());
 
-  // Add edges for each target
-  //    Process libraries before executables so their outputs exist
-  //    when executables reference them as link inputs
+  // 3. Add edges for each target.
+  //    Libraries are processed before executables so their output nodes
+  //    exist when executables reference them as link inputs.
   std::vector<Node*> output_nodes;
   for (const auto& t : project.targets()) {
     if (t->kind() == TargetKind::StaticLibrary) {
@@ -255,15 +307,17 @@ int NinjaBridge::build(const Project& project) {
     }
   }
 
-  // Configure the build
+  // 4. Configure the builder.
   BuildConfig config;
   config.verbosity = BuildConfig::NORMAL;
   config.parallelism = std::thread::hardware_concurrency();
-  static constexpr int kDefaultParallelism = 4;
-  if (config.parallelism == 0)
-    config.parallelism = kDefaultParallelism;
 
-  // Set up build infrastructure
+  static constexpr int kDefaultParallelism = 4;
+  if (config.parallelism == 0) {
+    config.parallelism = kDefaultParallelism;
+  }
+
+  // 5. Set up build infrastructure (logs, disk, status).
   BuildLog build_log;
   DepsLog deps_log;
   RealDiskInterface disk_interface;
@@ -271,9 +325,10 @@ int NinjaBridge::build(const Project& project) {
 
   std::filesystem::create_directories(".ccbuild");
 
-  // Load existing logs for incremental build support, then open for writing
   std::string err;
   NullBuildLogUser log_user;
+
+  // Load existing logs for incremental build support.
   if (!build_log.Load(".ccbuild/.ninja_log", &err)) {
     fprintf(stderr, "ccbuild: warning: loading build log: %s\n", err.c_str());
     err.clear();
@@ -291,11 +346,11 @@ int NinjaBridge::build(const Project& project) {
     return 1;
   }
 
-  int64_t start = GetTimeMillis();
+  // 6. Create the builder and add all output nodes as build targets.
+  const int64_t start = GetTimeMillis();
   Builder builder(&state, config, &build_log, &deps_log, &disk_interface,
                   &status, start);
 
-  // Add all output nodes as build targets
   for (auto* node : output_nodes) {
     if (!builder.AddTarget(node, &err)) {
       fprintf(stderr, "ccbuild: error adding target: %s\n", err.c_str());
@@ -303,14 +358,14 @@ int NinjaBridge::build(const Project& project) {
     }
   }
 
-  // Check if already up to date
+  // 7. Check if already up to date.
   if (builder.AlreadyUpToDate()) {
     printf("ccbuild: nothing to do, already up to date.\n");
     return 0;
   }
 
-  // Run the build
-  ExitStatus exit_status = builder.Build(&err);
+  // 8. Run the build.
+  const ExitStatus exit_status = builder.Build(&err);
   if (exit_status != ExitSuccess) {
     fprintf(stderr, "ccbuild: build failed: %s\n", err.c_str());
     return static_cast<int>(exit_status);

--- a/src/internal/ninja_bridge.cc
+++ b/src/internal/ninja_bridge.cc
@@ -115,6 +115,7 @@ void create_rules(State& state, const std::string& compiler, int standard) {
     EvalString cmd;
     text(cmd, "ar rcs ");
     var(cmd, "ldflags");  // per-target linker flags
+    text(cmd, " ");
     var(cmd, "out");
     text(cmd, " ");
     var(cmd, "in");
@@ -129,7 +130,7 @@ void create_rules(State& state, const std::string& compiler, int standard) {
   }
 }
 
-// -- Target Graph → Ninja Edges ------------------------------------------
+// -- Target Graph -> Ninja Edges -----------------------------------------
 
 /// Translate a single Target into Ninja Edges and Nodes.
 ///
@@ -258,10 +259,21 @@ Node* add_target_edges(State& state, const Target& target) {
     state.AddIn(final_edge, obj_node->path(), 0);
   }
 
-  // Inputs: outputs of link dependencies (for linking libraries together).
-  for (const Target& dep : target.link_deps()) {
-    const std::string dep_output = dep.output_filename();
-    state.AddIn(final_edge, dep_output, 0);
+  // Libraries: only archive own object files (no link-dep archives).
+  // Executables: recursively collect all transitive library archives.
+  if (target.kind() == TargetKind::Executable) {
+    std::unordered_set<std::string_view> link_visited;
+    std::function<void(const Target&)> collect_link_inputs =
+        [&](const Target& t) {
+          for (const Target& dep : t.link_deps()) {
+            if (link_visited.insert(dep.name()).second) {
+              const std::string dep_output = dep.output_filename();
+              state.AddIn(final_edge, dep_output, 0);
+              collect_link_inputs(dep);
+            }
+          }
+        };
+    collect_link_inputs(target);
   }
 
   std::string err;

--- a/src/internal/ninja_bridge.h
+++ b/src/internal/ninja_bridge.h
@@ -4,12 +4,26 @@
 namespace ccbuild {
 
 class Project;
-/// Bridge between ccbuild's project model and ninja's internal build system
-/// populates ninja's state with Rules and Edges derived from the Project
+
+/// Bridge between ccbuild's project model and Ninja's in-memory build engine.
+///
+/// Translates the high-level Project / Target graph into Ninja Rules and
+/// Edges, sets up build/deps logs, and invokes the Ninja Builder.
+///
+/// This is a stateless, function-level interface -- the only public entry
+/// point is the static NinjaBridge::build().
 class NinjaBridge {
  public:
-  /// Build the project using ninja's in-memory engine.
-  /// @return 0 on success, non-zero on failure
+  /// Build the project using Ninja's in-memory engine.
+  ///
+  ///  1. Detects the C++ compiler.
+  ///  2. Creates Ninja build rules (cc, link, ar).
+  ///  3. Populates the Ninja build graph from the Project targets.
+  ///  4. Loads/existing build/deps logs for incremental builds.
+  ///  5. Runs the Ninja Builder.
+  ///
+  /// @param project  A fully configured and valid Project.
+  /// @return 0 on success, non-zero on build failure.
   [[nodiscard]] static int build(const Project& project);
 };
 

--- a/src/internal/validators.h
+++ b/src/internal/validators.h
@@ -4,12 +4,19 @@
 #include <string_view>
 
 namespace ccbuild::validators {
+
+/// Check whether a file path has a recognized C++ source extension.
+///
+/// Accepted extensions: .cc, .cpp, .cxx, .c++, .c, .C
+///
+/// @param path  A file path (need not exist on disk).
+/// @return true if the extension indicates a C++ source file.
 [[nodiscard]] inline bool is_cpp_source(std::string_view path) {
-  auto dot = path.rfind('.');
+  const auto dot = path.rfind('.');
   if (dot == std::string_view::npos) {
     return false;
   }
-  auto ext = path.substr(dot);
+  const auto ext = path.substr(dot);
   return ext == ".cc" || ext == ".cpp" || ext == ".cxx" || ext == ".c++" ||
          ext == ".c" || ext == ".C";
 }

--- a/src/project/project.cc
+++ b/src/project/project.cc
@@ -5,17 +5,25 @@
 #include <map>
 #include <ranges>
 #include <set>
+#include <string>
+#include <string_view>
 
 #include "internal/ninja_bridge.h"
 #include "internal/validators.h"
 
 namespace ccbuild {
 
+// -- Construction --------------------------------------------------------
+
 Project::Project(std::string_view name) : name_(name) {}
 
-void Project::set_cxx_standard(int std) {
-  standard_ = std;
+// -- Configuration -------------------------------------------------------
+
+void Project::set_cxx_standard(int cxx_standard) {
+  standard_ = cxx_standard;
 }
+
+// -- Target Registration -------------------------------------------------
 
 Executable& Project::add_executable(
     std::string_view name, std::initializer_list<std::string> sources) {
@@ -35,7 +43,10 @@ StaticLibrary& Project::add_library(
   return *ptr;
 }
 
+// -- Validation ----------------------------------------------------------
+
 std::optional<std::string> Project::validate() const {
+  // Check for duplicate target names.
   std::set<std::string_view> names;
   for (const auto& t : targets_) {
     if (!names.insert(t->name()).second) {
@@ -44,6 +55,7 @@ std::optional<std::string> Project::validate() const {
     }
   }
 
+  // Every target must have at least one source file.
   for (const auto& t : targets_) {
     if (t->sources().empty()) {
       return std::string("target '") + std::string(t->name()) +
@@ -51,6 +63,7 @@ std::optional<std::string> Project::validate() const {
     }
   }
 
+  // All source files must have recognised C++ extensions.
   for (const auto& t : targets_) {
     for (const auto& src : t->sources()) {
       if (!validators::is_cpp_source(src)) {
@@ -61,6 +74,7 @@ std::optional<std::string> Project::validate() const {
     }
   }
 
+  // Executables must not link against other executables.
   for (const auto& t : targets_) {
     for (const Target& dep : t->link_deps()) {
       if (dep.kind() == TargetKind::Executable) {
@@ -71,6 +85,7 @@ std::optional<std::string> Project::validate() const {
     }
   }
 
+  // Detect link cycles using depth-first search with three-colour marking.
   enum class Mark { none, in_stack, done };
   std::map<std::string_view, Mark, std::less<>> marks;
 
@@ -82,31 +97,39 @@ std::optional<std::string> Project::validate() const {
         return std::string("link cycle involving '") + std::string(t.name()) +
                "' and '" + std::string(dep.name()) + "'";
       }
-      if (marks[dep.name()] == Mark::none)
-        if (auto err = visit(dep))
+      if (marks[dep.name()] == Mark::none) {
+        if (auto err = visit(dep)) {
           return err;
+        }
+      }
     }
     marks[t.name()] = Mark::done;
     return std::nullopt;
   };
 
   for (const auto& t : targets_) {
-    if (marks[t->name()] == Mark::none)
-      if (auto err = visit(*t))
+    if (marks[t->name()] == Mark::none) {
+      if (auto err = visit(*t)) {
         return err;
+      }
+    }
   }
 
   return std::nullopt;
 }
 
+// -- Build Execution -----------------------------------------------------
+
 int Project::build(bool dry_run) {
   using enum TargetKind;
 
+  // Validate before doing any work.
   if (auto err = validate()) {
     fprintf(stderr, "ccbuild: error: %s\n", err->c_str());
     return 1;
   }
 
+  // -- Print build plan --------------------------------------------------
   printf("ccbuild: project '%s' (C++%d)\n", name_.c_str(), standard_);
 
   size_t compile_count = 0;
@@ -114,6 +137,7 @@ int Project::build(bool dry_run) {
   size_t link_count = 0;
 
   for (const auto& t : targets_) {
+    // Human-readable target kind.
     const char* kind_str = [&] {
       switch (t->kind()) {
       case Executable:
@@ -127,19 +151,29 @@ int Project::build(bool dry_run) {
     printf("  target '%.*s' [%s] -> %s\n", static_cast<int>(t->name().size()),
            t->name().data(), kind_str, t->output_filename().c_str());
 
+    // Sources.
     printf("    sources:");
-    for (const auto& src : t->sources())
+    for (const auto& src : t->sources()) {
       printf(" %s", src.c_str());
+    }
     printf("\n");
 
+    // Compile options.
     if (!t->compile_options().empty()) {
       printf("    options:");
-      for (const auto& opt : t->compile_options())
+      for (const auto& opt : t->compile_options()) {
         printf(" %s", opt.c_str());
+      }
       printf("\n");
     }
 
+    // Include directories grouped by visibility.
     static constexpr int kVisibilityCount = 3;
+    static constexpr const char* kIncludeLabels[] = {
+      nullptr,               // [0] unused (visibility values start at 1)
+      "includes (PUBLIC):",  // Visibility::Public  == 0 → wait...
+    };
+    // Visibility values: Public=0, Private=1, Interface=2
     const char* include_labels[] = { nullptr, nullptr, nullptr };
     include_labels[static_cast<int>(Visibility::Public)] = "includes (PUBLIC):";
     include_labels[static_cast<int>(Visibility::Private)] =
@@ -150,19 +184,32 @@ int Project::build(bool dry_run) {
       auto dirs = t->include_dirs(static_cast<Visibility>(v));
       if (!dirs.empty()) {
         printf("    %s", include_labels[v]);
-        for (const auto& d : dirs)
+        for (const auto& d : dirs) {
           printf(" %s", d.c_str());
+        }
         printf("\n");
       }
     }
 
+    // Link dependencies.
     if (!t->link_deps().empty()) {
       printf("    links:");
-      for (const Target& dep : t->link_deps())
+      for (const Target& dep : t->link_deps()) {
         printf(" %.*s", static_cast<int>(dep.name().size()), dep.name().data());
+      }
       printf("\n");
     }
 
+    // Link options.
+    if (!t->link_options().empty()) {
+      printf("    link opts:");
+      for (const auto& opt : t->link_options()) {
+        printf(" %s", opt.c_str());
+      }
+      printf("\n");
+    }
+
+    // Per-source compile plan.
     auto obj_paths =
         t->sources() | std::views::transform([&](std::string_view src) {
           return t->object_path(src);
@@ -176,6 +223,7 @@ int Project::build(bool dry_run) {
       ++compile_count;
     }
 
+    // Final artifact step.
     switch (t->kind()) {
     case StaticLibrary:
       printf("    archive: -> %s\n", t->output_filename().c_str());
@@ -191,8 +239,11 @@ int Project::build(bool dry_run) {
   printf("  plan: %zu compile, %zu archive, %zu link\n", compile_count,
          archive_count, link_count);
 
-  if (dry_run)
+  if (dry_run) {
     return 0;
+  }
+
+  // Delegate to Ninja for the actual build.
   return NinjaBridge::build(*this);
 }
 

--- a/src/targets/executable.cc
+++ b/src/targets/executable.cc
@@ -1,6 +1,7 @@
 #include "ccbuild/executable.h"
 
 namespace ccbuild {
+
 Executable::Executable(std::string_view name, std::vector<std::string> sources)
     : Target(name, std::move(sources)) {}
 

--- a/src/targets/static_library.cc
+++ b/src/targets/static_library.cc
@@ -1,6 +1,7 @@
 #include "ccbuild/static_library.h"
 
 namespace ccbuild {
+
 StaticLibrary::StaticLibrary(std::string_view name,
                              std::vector<std::string> sources)
     : Target(name, std::move(sources)) {}

--- a/tests/core/target_test.cc
+++ b/tests/core/target_test.cc
@@ -8,7 +8,9 @@
 
 namespace ccbuild {
 namespace {
-/// Construction
+
+// -- Construction --------------------------------------------------------
+
 TEST(TargetTest, NameIsPreserved) {
   Executable t("myapp", { "main.cc" });
   EXPECT_EQ(t.name(), "myapp");
@@ -27,7 +29,8 @@ TEST(TargetTest, EmptySourcesAllowed) {
   EXPECT_TRUE(t.sources().empty());
 }
 
-/// add_sources
+// -- add_sources ---------------------------------------------------------
+
 TEST(TargetTest, AddSourcesFromInitializerList) {
   Executable t("myapp", { "a.cc" });
   t.add_sources({ "b.cc", "c.cc" });
@@ -43,7 +46,8 @@ TEST(TargetTest, AddSourcesFromVector) {
   EXPECT_EQ(t.sources()[0], "a.cc");
 }
 
-/// link
+// -- link ----------------------------------------------------------------
+
 TEST(TargetTest, LinkDepsInitiallyEmpty) {
   Executable t("myapp", { "main.cc" });
   EXPECT_TRUE(t.link_deps().empty());
@@ -69,7 +73,8 @@ TEST(TargetTest, LinkMultipleDeps) {
   EXPECT_EQ(app.link_deps()[1].get().name(), "b");
 }
 
-/// add_compile_options
+// -- add_compile_options -------------------------------------------------
+
 TEST(TargetTest, CompileOptionsInitiallyEmpty) {
   Executable app("myapp", { "main.cc" });
   EXPECT_TRUE(app.compile_options().empty());
@@ -90,7 +95,8 @@ TEST(TargetTest, AddCompileOptionsAccumulates) {
   EXPECT_EQ(app.compile_options().size(), 3u);
 }
 
-/// object_path
+// -- object_path ---------------------------------------------------------
+
 TEST(TargetTest, ObjectPathSimpleFilename) {
   Executable app("myapp", { "main.cc" });
   EXPECT_EQ(app.object_path("main.cc"), ".ccbuild/obj/myapp/main.o");
@@ -126,19 +132,20 @@ TEST(TargetTest, ObjectPathCollisionDifferentDirs) {
   EXPECT_EQ(iodir, ".ccbuild/obj/myapp/src/io/socket.o");
 }
 
-/// fluent API chaining
+// -- Fluent API chaining -------------------------------------------------
+
 TEST(TargetTest, FluentChaining) {
   StaticLibrary dep("dep", { "dep.cc" });
   Executable t("myapp", { "main.cc" });
 
-  // All methods return Target& for chaining
   auto& ref = t.link(dep).add_compile_options({ "-Wall" });
   EXPECT_EQ(&ref, &t);
   EXPECT_EQ(t.link_deps().size(), 1u);
   EXPECT_EQ(t.compile_options().size(), 1u);
 }
 
-/// include directories
+// -- Include directories -------------------------------------------------
+
 TEST(TargetTest, IncludeDirsInitiallyEmpty) {
   Executable t("myapp", { "main.cc" });
   EXPECT_TRUE(t.include_dirs(Visibility::Private).empty());
@@ -185,7 +192,8 @@ TEST(TargetTest, AddIncludeDirsMultipleVisibilities) {
   EXPECT_EQ(t.include_dirs(Visibility::Interface).size(), 1u);
 }
 
-/// link exe->exe rejection
+// -- Link validation -----------------------------------------------------
+
 TEST(TargetTest, LinkExeToExeThrows) {
   Executable a("a", { "a.cc" });
   Executable b("b", { "b.cc" });

--- a/tests/internal/compiler_test.cc
+++ b/tests/internal/compiler_test.cc
@@ -39,6 +39,11 @@ TEST(IdentifyKindTest, ClangBeatsGcc) {
   EXPECT_EQ(identify_kind("clang with gcc compatibility"), CompilerKind::Clang);
 }
 
+TEST(IdentifyKindTest, DetectsLowercaseGcc) {
+  EXPECT_EQ(identify_kind("gcc version 4.8.5"), CompilerKind::Gcc);
+  EXPECT_EQ(identify_kind("SomeTool based on gcc 9.3.0"), CompilerKind::Gcc);
+}
+
 // -- extract_version -----------------------------------------------------
 
 TEST(ExtractVersionTest, ExtractsStandardVersion) {

--- a/tests/internal/compiler_test.cc
+++ b/tests/internal/compiler_test.cc
@@ -6,6 +6,8 @@ namespace ccbuild {
 namespace internal {
 namespace {
 
+// -- identify_kind -------------------------------------------------------
+
 TEST(IdentifyKindTest, DetectsClang) {
   EXPECT_EQ(identify_kind("clang version 15.0.0"), CompilerKind::Clang);
   EXPECT_EQ(identify_kind("Apple clang version 14.0.3 (clang-1403.0.22.14.1)"),
@@ -37,6 +39,8 @@ TEST(IdentifyKindTest, ClangBeatsGcc) {
   EXPECT_EQ(identify_kind("clang with gcc compatibility"), CompilerKind::Clang);
 }
 
+// -- extract_version -----------------------------------------------------
+
 TEST(ExtractVersionTest, ExtractsStandardVersion) {
   EXPECT_EQ(extract_version("g++ (GCC) 11.5.0"), "11.5.0");
   EXPECT_EQ(extract_version("clang version 15.0.0 (git-hash)"), "15.0.0");
@@ -53,6 +57,8 @@ TEST(ExtractVersionTest, EmptyInputReturnsEmpty) {
 TEST(ExtractVersionTest, FirstMatchWins) {
   EXPECT_EQ(extract_version("version 1.2.3 and 4.5.6"), "1.2.3");
 }
+
+// -- extract_major -------------------------------------------------------
 
 TEST(ExtractMajorTest, ExtractsNormalVersion) {
   EXPECT_EQ(extract_major("11.5.0"), 11);

--- a/tests/internal/ninja_bridge_test.cc
+++ b/tests/internal/ninja_bridge_test.cc
@@ -1,0 +1,454 @@
+#include "internal/ninja_bridge.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+
+#include "ccbuild/project.h"
+
+namespace ccbuild {
+namespace internal {
+namespace {
+
+// -- RAII helpers ---------------------------------------------------------
+
+struct TempFile {
+  std::string path;
+  explicit TempFile(std::string p) : path(std::move(p)) {}
+  ~TempFile() { std::filesystem::remove(path); }
+  TempFile(const TempFile&) = delete;
+  TempFile& operator=(const TempFile&) = delete;
+};
+
+struct TempDir {
+  std::filesystem::path path;
+  explicit TempDir(std::filesystem::path p) : path(std::move(p)) {
+    std::filesystem::create_directories(path);
+  }
+  ~TempDir() {
+    std::error_code ec;
+    std::filesystem::remove_all(path, ec);
+  }
+  TempDir(const TempDir&) = delete;
+  TempDir& operator=(const TempDir&) = delete;
+};
+
+// -- Fixture --------------------------------------------------------------
+
+class NinjaBridgeTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::filesystem::remove_all(".ccbuild");
+
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::directory_iterator(".", ec)) {
+      if (ec)
+        break;
+      const auto& p = entry.path();
+      const auto name = p.filename().string();
+      bool is_test_file = (name.find("_nb_test_") == 0) ||
+                          (name == "ninja_bridge_test_dummy.cc") ||
+                          (name == "ninja_bridge_test_lib.cc") ||
+                          (name == "ninja_bridge_test_main.cc");
+      if (is_test_file) {
+        std::filesystem::remove_all(p, ec);
+      }
+      ec.clear();
+    }
+  }
+
+  void TearDown() override { std::filesystem::remove_all(".ccbuild"); }
+};
+
+TEST_F(NinjaBridgeTest, EmptyProjectSucceeds) {
+  const Project p("empty_project");
+
+  testing::internal::CaptureStdout();
+  const int result = NinjaBridge::build(p);
+  const std::string out = testing::internal::GetCapturedStdout();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_NE(out.find("nothing to do"), std::string::npos);
+}
+
+TEST_F(NinjaBridgeTest, BuildFailsOnMissingSource) {
+  Project p("missing_src_project");
+  p.add_executable("app", { "does_not_exist.cc" });
+
+  testing::internal::CaptureStderr();
+  testing::internal::CaptureStdout();
+  const int result = NinjaBridge::build(p);
+  const std::string out = testing::internal::GetCapturedStdout();
+  const std::string err = testing::internal::GetCapturedStderr();
+
+  EXPECT_NE(result, 0);
+  bool has_error = (out.find("error") != std::string::npos) ||
+                   (err.find("error") != std::string::npos);
+  EXPECT_TRUE(has_error);
+}
+
+TEST_F(NinjaBridgeTest, BuildSucceedsWithValidSource) {
+  const std::string src_file = "ninja_bridge_test_dummy.cc";
+
+  {
+    std::ofstream f(src_file);
+    ASSERT_TRUE(f.is_open());
+    f << "int main() { return 0; }\n";
+  }
+
+  Project p("dummy_project");
+  p.add_executable("dummy_app", { src_file });
+
+  testing::internal::CaptureStdout();
+  testing::internal::CaptureStderr();
+  const int result = NinjaBridge::build(p);
+  testing::internal::GetCapturedStdout();
+  testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/bin/dummy_app"));
+}
+
+TEST_F(NinjaBridgeTest, BuildSucceedsWithComplexGraph) {
+  const std::string lib_src = "ninja_bridge_test_lib.cc";
+  const std::string main_src = "ninja_bridge_test_main.cc";
+
+  {
+    std::ofstream f(lib_src);
+    ASSERT_TRUE(f.is_open());
+    f << "int the_answer() { return 42; }\n";
+  }
+  {
+    std::ofstream f(main_src);
+    ASSERT_TRUE(f.is_open());
+    f << "int the_answer();\n"
+         "int main() { return the_answer() == 42 ? 0 : 1; }\n";
+  }
+
+  Project p("complex_project");
+
+  auto& lib = p.add_library("my_lib", { lib_src });
+  lib.add_include_dirs({ "include" }, Visibility::Public);
+  lib.add_include_dirs({ "src" }, Visibility::Private);
+  lib.add_compile_options({ "-DTEST_DEFINE" });
+
+  auto& app = p.add_executable("my_app", { main_src });
+  app.link(lib);
+  app.add_link_options({ "-O0" });
+  app.add_include_dirs({ "app_include" }, Visibility::Interface);
+
+  testing::internal::CaptureStdout();
+  testing::internal::CaptureStderr();
+  const int result = NinjaBridge::build(p);
+  testing::internal::GetCapturedStdout();
+  testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/bin/my_app"));
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/lib/libmy_lib.a"));
+}
+
+TEST_F(NinjaBridgeTest, LibraryWithLinkOptionsBuildsCorrectly) {
+  TempFile src("_nb_test_ar_src.cc");
+  {
+    std::ofstream f(src.path);
+    f << "int func() { return 1; }\n";
+  }
+
+  Project p("ar_test");
+  auto& lib = p.add_library("my_lib", { src.path });
+  lib.add_link_options({ "-s" });
+
+  testing::internal::CaptureStdout();
+  testing::internal::CaptureStderr();
+  const int result = NinjaBridge::build(p);
+  testing::internal::GetCapturedStdout();
+  testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/lib/libmy_lib.a"));
+}
+
+TEST_F(NinjaBridgeTest, InterfaceIncludeDirsPropagateToLinker) {
+  TempDir inc("_nb_test_iface_inc");
+  TempFile lib_src("_nb_test_iface_lib.cc");
+  TempFile exe_src("_nb_test_iface_exe.cc");
+
+  {
+    std::ofstream f((inc.path / "util.h").string());
+    f << "#pragma once\ninline int util() { return 99; }\n";
+  }
+  {
+    std::ofstream f(lib_src.path);
+    f << "int lib_func() { return 1; }\n";
+  }
+  {
+    std::ofstream f(exe_src.path);
+    f << "#include \"util.h\"\n"
+         "int lib_func();\n"
+         "int main() { return lib_func() + util() == 100 ? 0 : 1; }\n";
+  }
+
+  Project p("iface_test");
+  auto& lib = p.add_library("mylib", { lib_src.path });
+  lib.add_include_dirs({ inc.path.string() }, Visibility::Interface);
+  auto& app = p.add_executable("myapp", { exe_src.path });
+  app.link(lib);
+
+  testing::internal::CaptureStdout();
+  testing::internal::CaptureStderr();
+  const int result = NinjaBridge::build(p);
+  testing::internal::GetCapturedStdout();
+  testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/bin/myapp"));
+}
+
+TEST_F(NinjaBridgeTest, SecondBuildAlreadyUpToDate) {
+  TempFile src("_nb_test_uptodate.cc");
+  {
+    std::ofstream f(src.path);
+    f << "int main() { return 0; }\n";
+  }
+
+  Project p("uptodate_test");
+  p.add_executable("app", { src.path });
+
+  {
+    testing::internal::CaptureStdout();
+    testing::internal::CaptureStderr();
+    const int result = NinjaBridge::build(p);
+    testing::internal::GetCapturedStdout();
+    testing::internal::GetCapturedStderr();
+    EXPECT_EQ(result, 0);
+  }
+
+  testing::internal::CaptureStdout();
+  const int result = NinjaBridge::build(p);
+  const std::string out = testing::internal::GetCapturedStdout();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_NE(out.find("nothing to do"), std::string::npos);
+}
+
+TEST_F(NinjaBridgeTest, BuildFailsOnCompilationError) {
+  TempFile src("_nb_test_comperr.cc");
+  {
+    std::ofstream f(src.path);
+    f << "int main() { return 1 }\n";
+  }
+
+  Project p("comperr_test");
+  p.add_executable("app", { src.path });
+
+  testing::internal::CaptureStderr();
+  testing::internal::CaptureStdout();
+  const int result = NinjaBridge::build(p);
+  const std::string out = testing::internal::GetCapturedStdout();
+  const std::string err = testing::internal::GetCapturedStderr();
+
+  EXPECT_NE(result, 0);
+  bool has_error = (out.find("error") != std::string::npos) ||
+                   (err.find("error") != std::string::npos);
+  EXPECT_TRUE(has_error);
+}
+
+TEST_F(NinjaBridgeTest, SourceInSubdirectoryBuildsCorrectObject) {
+  TempDir src_dir("_nb_test_src");
+  TempFile src((src_dir.path / "main.cc").string());
+
+  {
+    std::ofstream f(src.path);
+    f << "int main() { return 0; }\n";
+  }
+
+  Project p("subdir_test");
+  p.add_executable("app", { src.path });
+
+  testing::internal::CaptureStdout();
+  testing::internal::CaptureStderr();
+  const int result = NinjaBridge::build(p);
+  testing::internal::GetCapturedStdout();
+  testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/obj/app/_nb_test_src/main.o"));
+}
+
+TEST_F(NinjaBridgeTest, MultiDepthTransitiveIncludes) {
+  TempDir inc_a("_nb_test_inc_a");
+  TempDir inc_b("_nb_test_inc_b");
+  TempFile liba_src("_nb_test_trans_a.cc");
+  TempFile libb_src("_nb_test_trans_b.cc");
+  TempFile exe_src("_nb_test_trans_exe.cc");
+
+  {
+    std::ofstream f((inc_a.path / "a.h").string());
+    f << "#pragma once\nint func_a();\n";
+  }
+  {
+    std::ofstream f((inc_b.path / "b.h").string());
+    f << "#pragma once\nint func_b();\n";
+  }
+  {
+    std::ofstream f(liba_src.path);
+    f << "int func_a() { return 1; }\n";
+  }
+  {
+    std::ofstream f(libb_src.path);
+    f << "#include \"a.h\"\n"
+         "#include \"b.h\"\n"
+         "int func_b() { return func_a() + 1; }\n";
+  }
+  {
+    std::ofstream f(exe_src.path);
+    f << "#include \"b.h\"\n"
+         "int main() { return func_b() == 2 ? 0 : 1; }\n";
+  }
+
+  Project p("trans_test");
+  auto& liba = p.add_library("liba", { liba_src.path });
+  liba.add_include_dirs({ inc_a.path.string() }, Visibility::Public);
+
+  auto& libb = p.add_library("libb", { libb_src.path });
+  libb.add_include_dirs({ inc_b.path.string() }, Visibility::Public);
+  libb.link(liba);
+
+  auto& app = p.add_executable("app", { exe_src.path });
+  app.link(libb);
+
+  testing::internal::CaptureStdout();
+  testing::internal::CaptureStderr();
+  const int result = NinjaBridge::build(p);
+  testing::internal::GetCapturedStdout();
+  testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/bin/app"));
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/lib/libliba.a"));
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/lib/liblibb.a"));
+}
+
+TEST_F(NinjaBridgeTest, TwoExecutablesBuildBoth) {
+  TempFile src1("_nb_test_two_1.cc");
+  TempFile src2("_nb_test_two_2.cc");
+
+  {
+    std::ofstream f(src1.path);
+    f << "int main() { return 0; }\n";
+  }
+  {
+    std::ofstream f(src2.path);
+    f << "int main() { return 1; }\n";
+  }
+
+  Project p("two_exe_test");
+  p.add_executable("app1", { src1.path });
+  p.add_executable("app2", { src2.path });
+
+  testing::internal::CaptureStdout();
+  testing::internal::CaptureStderr();
+  const int result = NinjaBridge::build(p);
+  testing::internal::GetCapturedStdout();
+  testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/bin/app1"));
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/bin/app2"));
+}
+
+TEST_F(NinjaBridgeTest, MultipleLinkOptionsSeparation) {
+  TempFile src("_nb_test_mlo.cc");
+  {
+    std::ofstream f(src.path);
+    f << "int main() { return 0; }\n";
+  }
+
+  Project p("mlo_test");
+  auto& app = p.add_executable("app", { src.path });
+  app.add_link_options({ "-O0", "-Wl,-dead_strip" });
+
+  testing::internal::CaptureStdout();
+  testing::internal::CaptureStderr();
+  const int result = NinjaBridge::build(p);
+  testing::internal::GetCapturedStdout();
+  testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/bin/app"));
+}
+
+TEST_F(NinjaBridgeTest, CompileOptionsWithoutIncludeDirs) {
+  TempFile src("_nb_test_co.cc");
+  {
+    std::ofstream f(src.path);
+    f << "int main() { return 0; }\n";
+  }
+
+  Project p("co_test");
+  auto& app = p.add_executable("app", { src.path });
+  app.add_compile_options({ "-Wall", "-Wextra" });
+
+  testing::internal::CaptureStdout();
+  testing::internal::CaptureStderr();
+  const int result = NinjaBridge::build(p);
+  testing::internal::GetCapturedStdout();
+  testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/bin/app"));
+}
+
+TEST_F(NinjaBridgeTest, DuplicateTransitiveLinkDeps) {
+  TempFile base_src("_nb_test_dup_base.cc");
+  TempFile mid1_src("_nb_test_dup_mid1.cc");
+  TempFile mid2_src("_nb_test_dup_mid2.cc");
+  TempFile exe_src("_nb_test_dup_exe.cc");
+
+  {
+    std::ofstream f(base_src.path);
+    f << "int base_func() { return 1; }\n";
+  }
+  {
+    std::ofstream f(mid1_src.path);
+    f << "int base_func();\n"
+         "int mid1_func() { return base_func() + 1; }\n";
+  }
+  {
+    std::ofstream f(mid2_src.path);
+    f << "int base_func();\n"
+         "int mid2_func() { return base_func() + 2; }\n";
+  }
+  {
+    std::ofstream f(exe_src.path);
+    f << "int mid1_func();\n"
+         "int mid2_func();\n"
+         "int main() { return (mid1_func() + mid2_func()) == 5 ? 0 : 1; }\n";
+  }
+
+  Project p("dup_deps_test");
+  auto& base = p.add_library("base", { base_src.path });
+  auto& mid1 = p.add_library("mid1", { mid1_src.path });
+  auto& mid2 = p.add_library("mid2", { mid2_src.path });
+  mid1.link(base);
+  mid2.link(base);
+  auto& app = p.add_executable("app", { exe_src.path });
+  app.link(mid1).link(mid2);
+
+  testing::internal::CaptureStdout();
+  testing::internal::CaptureStderr();
+  const int result = NinjaBridge::build(p);
+  testing::internal::GetCapturedStdout();
+  testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(result, 0);
+  EXPECT_TRUE(std::filesystem::exists(".ccbuild/bin/app"));
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace ccbuild

--- a/tests/internal/validators_test.cc
+++ b/tests/internal/validators_test.cc
@@ -7,12 +7,16 @@
 namespace ccbuild {
 namespace {
 
+// -- CompilerInfo::kind_str ----------------------------------------------
+
 TEST(CompilerInfoTest, KindStrMapping) {
   EXPECT_EQ((CompilerInfo{ .kind = CompilerKind::Gcc }).kind_str(), "GCC");
   EXPECT_EQ((CompilerInfo{ .kind = CompilerKind::Clang }).kind_str(), "Clang");
   EXPECT_EQ((CompilerInfo{ .kind = CompilerKind::Unknown }).kind_str(),
             "Unknown");
 }
+
+// -- detect_compiler -----------------------------------------------------
 
 TEST(DetectCompilerTest, FindsDefaultCompiler) {
   unsetenv("CXX");
@@ -51,9 +55,11 @@ TEST(DetectCompilerTest, VersionHasThreeComponents) {
   auto info = detect_compiler();
   ASSERT_TRUE(info.has_value());
   int dots = 0;
-  for (char c : info->version)
-    if (c == '.')
-      dots++;
+  for (char c : info->version) {
+    if (c == '.') {
+      ++dots;
+    }
+  }
   EXPECT_EQ(dots, 2);
 }
 
@@ -66,6 +72,8 @@ TEST(DetectCompilerTest, MajorVersionMatchesVersionString) {
   int expected_major = std::stoi(info->version.substr(0, dot_pos));
   EXPECT_EQ(info->major_version, expected_major);
 }
+
+// -- is_cpp_source -------------------------------------------------------
 
 TEST(IsCppSourceTest, RejectsNoExtension) {
   EXPECT_FALSE(validators::is_cpp_source("Makefile"));

--- a/tests/project/project_test.cc
+++ b/tests/project/project_test.cc
@@ -9,10 +9,14 @@
 namespace ccbuild {
 namespace {
 
+// -- Default Settings ----------------------------------------------------
+
 TEST(ProjectTest, DefaultStandardIs17) {
   Project p("myproject");
   EXPECT_EQ(p.standard(), 17);
 }
+
+// -- Adding Targets ------------------------------------------------------
 
 TEST(ProjectTest, AddExecutableReturnsReference) {
   Project p("test");
@@ -35,6 +39,8 @@ TEST(ProjectTest, AddLibraryReturnsReference) {
   EXPECT_EQ(lib.kind(), TargetKind::StaticLibrary);
 }
 
+// -- Basic Build ---------------------------------------------------------
+
 TEST(ProjectTest, BuildSucceedsOnValidProject) {
   Project p("test");
   p.add_executable("myapp", { "main.cc" });
@@ -48,6 +54,8 @@ TEST(ProjectTest, BuildSucceedsWithLinkDeps) {
   exe.link(lib);
   EXPECT_EQ(p.build(/*dry_run=*/true), 0);
 }
+
+// -- Validation: Duplicate Names -----------------------------------------
 
 TEST(ProjectTest, BuildFailsOnDuplicateTargetNames) {
   Project p("test");
@@ -76,6 +84,8 @@ TEST(ProjectTest, BuildFailsOnDuplicateExeAndLibName) {
   EXPECT_NE(err.find("duplicate target name"), std::string::npos);
 }
 
+// -- Validation: Empty Sources -------------------------------------------
+
 TEST(ProjectTest, BuildFailsOnEmptySources) {
   Project p("test");
   p.add_executable("myapp", {});
@@ -89,6 +99,8 @@ TEST(ProjectTest, BuildFailsOnEmptySources) {
   EXPECT_NE(err.find("myapp"), std::string::npos);
 }
 
+// -- Validation: Invalid Extensions --------------------------------------
+
 TEST(ProjectTest, BuildFailsOnInvalidSourceExtension) {
   Project p("test");
   p.add_executable("myapp", { "Makefile" });
@@ -101,6 +113,8 @@ TEST(ProjectTest, BuildFailsOnInvalidSourceExtension) {
   EXPECT_NE(err.find("invalid source file"), std::string::npos);
   EXPECT_NE(err.find("Makefile"), std::string::npos);
 }
+
+// -- Validation: Executable Link Rules -----------------------------------
 
 TEST(ProjectTest, LinkingExeToExeThrows) {
   Executable a("a", { "a.cc" });
@@ -116,6 +130,8 @@ TEST(ProjectTest, BuildSucceedsExeLinkingLib) {
   exe.link(lib);
   EXPECT_EQ(p.build(/*dry_run=*/true), 0);
 }
+
+// -- Validation: Link Cycles ---------------------------------------------
 
 TEST(ProjectTest, BuildFailsOnDirectLinkCycle) {
   Project p("test");
@@ -179,6 +195,8 @@ TEST(ProjectTest, BuildSucceedsOnDiamondDag) {
   EXPECT_EQ(p.build(/*dry_run=*/true), 0);
   testing::internal::GetCapturedStdout();
 }
+
+// -- Build Output --------------------------------------------------------
 
 TEST(ProjectTest, BuildOutputContainsProjectName) {
   Project p("coolproject");

--- a/tests/targets/executable_test.cc
+++ b/tests/targets/executable_test.cc
@@ -4,10 +4,15 @@
 
 namespace ccbuild {
 namespace {
+
+// -- Target Kind ---------------------------------------------------------
+
 TEST(ExecutableTest, KindIsExecutable) {
   Executable exe("myexe", { "main.cc" });
   EXPECT_EQ(exe.kind(), TargetKind::Executable);
 }
+
+// -- Output Filename -----------------------------------------------------
 
 TEST(ExecutableTest, OutputFilenameMatchesName) {
   Executable exe("myexe", { "main.cc" });

--- a/tests/targets/static_library_test.cc
+++ b/tests/targets/static_library_test.cc
@@ -4,10 +4,15 @@
 
 namespace ccbuild {
 namespace {
+
+// -- Target Kind ---------------------------------------------------------
+
 TEST(StaticLibraryTest, KindIsStaticLibrary) {
   StaticLibrary lib("mylib", { "lib.cc" });
   EXPECT_EQ(lib.kind(), TargetKind::StaticLibrary);
 }
+
+// -- Output Filename -----------------------------------------------------
 
 TEST(StaticLibraryTest, OutputFilenameHasLibPrefix) {
   StaticLibrary lib("mylib", { "lib.cc" });


### PR DESCRIPTION
## Summary

- Fix ninja bridge: libraries archive only own objects, executables recursively collect transitive link deps with dedup
- Add 14 integration tests for ninja bridge
- Add lowercase-gcc detection test for compiler
- Set coverage threshold to 85%
- Pin ninja submodule to v1.13.2

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] CI / Build

## Testing

- [x] All tests pass: 109 tests from 16 test suites
- [x] New gtest tests: 14 ninja bridge integration tests, 1 compiler test
- [x] Clang-format compliance on changed files
- [x] Coverage report looks good
- [x] My changes generate no new compiler warnings

## Checklist

- [x] I have written/updated gtest tests for my changes
- [x] All tests pass locally with ctest
- [x] Clang-format compliance on changed files
- [x] My changes generate no new compiler warnings
- [ ] I have updated documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added link options configuration API for targets
  * Enhanced build output with detailed information on sources, compile options, and dependencies

* **Bug Fixes**
  * Targets now required to have at least one source file
  * Executables can no longer link to other executables

* **Documentation**
  * Improved API documentation and header comments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->